### PR TITLE
Petite proposition d'amélioration pour le post sur les Gadt

### DIFF
--- a/posts/gadt-pour-les-debutants.org
+++ b/posts/gadt-pour-les-debutants.org
@@ -172,8 +172,8 @@ Dans cet exemple, src_ocaml{'b} sera le type des données de la liste, et on uti
 src_ocaml{'a} pour définir si la liste est vide ou non.
 
 #+BEGIN_SRC ocaml
-type empty_t 
-type not_empty_t 
+type empty_t = Empty_t
+type not_empty_t = Not_empty_t
 
 type 'a my_list =
  | Empty
@@ -198,8 +198,8 @@ nom. Nous allons pouvoir implémenter l'interface de notre module:
 
 
 #+BEGIN_SRC ocaml
- type empty_t
- type not_empty_t 
+ type empty_t = Empty_t
+ type not_empty_t = Not_empty_t
  type ('a, 'b) t
 
  val empty : (empty_t, 'a) t


### PR DESCRIPTION
Bonjour,

En parcourant le web en recherche de blog sur les GADTs pour OCaml, je suis tombé sur ce post qui est intéressant mais se heurte à une subtilité dans l'utilisation des GADTs.

Lorsqu'on utilise un type comme un tag dans un GADT (comme `empty_t` et `non_empty_t` dans ton exemple) , il est préférable de toujours l'associer avec un constructeur. Par exemple

```OCaml
type empty = Empty
```

Aussi non, on se trouve avec un code qui ne marche qu'au sein du module qui a défini le type utilisé comme tag. Typiquement, tout marche correctement dans le module `M`

```OCaml
module M = struct
  type empty
  type non_empty
  type _ list = []: empty list |(::): int * _ list -> non_empty list
  let work: empty list -> unit = function [] -> () | _ -> .
end
```
mais dès qu'on sort du module, la même fonction ne marche plus 

```OCaml
let dont_work_anymore: M.empty M.list -> unit  = function [] -> () | _ -> .
```
parce que le typechecker ne sait plus prover que `empty_t <> not_empty_t`.